### PR TITLE
SERVER-104338: Omit warnings if a specific artifact could not be found.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/downloader/GrpcRemoteDownloader.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/downloader/GrpcRemoteDownloader.java
@@ -165,8 +165,23 @@ public class GrpcRemoteDownloader implements AutoCloseable, Downloader {
         }
         throw e;
       }
-      eventHandler.handle(
-          Event.warn("Remote Cache: " + Utils.grpcAwareErrorMessage(e, verboseFailures)));
+
+      Optional<String> url = urls.stream()
+          .filter(u -> e.toString().contains(u.toString()))
+          .map(URL::toString)
+          .findFirst();
+
+      boolean warn = true;
+      if (url.isPresent()) {
+        warn = !(options.remoteDownloadOmitLocalFetchWarningUrls.stream()
+            .anyMatch(u -> url.get().startsWith(u)));
+      }
+
+      if (warn) {
+        eventHandler.handle(
+            Event.warn("Remote Cache: " + Utils.grpcAwareErrorMessage(e, verboseFailures)));
+      }
+      
       fallbackDownloader.download(
           urls,
           headers,

--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
@@ -147,6 +147,19 @@ public final class RemoteOptions extends CommonRemoteOptions {
   public boolean remoteDownloaderLocalFallback;
 
   @Option(
+    name = "experimental_remote_download_omit_local_fetch_warning_url",
+    defaultValue = "null",
+    documentationCategory = OptionDocumentationCategory.REMOTE,
+    effectTags = {OptionEffectTag.UNKNOWN},
+    help = 
+        "Omit the warning if the fetched file is not found in the remote cache."
+           + " The value of this flag is an URL that will match the prefix of the"
+           + " URL that tried to fetch remotely. The URL should be in the format of"
+           + " https://example.com/one/two.",
+    allowMultiple = true)
+  public List<String> remoteDownloadOmitLocalFetchWarningUrls;
+
+  @Option(
       name = "remote_header",
       converter = Converters.AssignmentConverter.class,
       defaultValue = "null",


### PR DESCRIPTION
This patchset contains a new flag named
experimental_remote_download_omit_local_fetch_warning_url that omits warnings being displayed to the user if an artifact could not be fetched remotely from engflow. This requires the experimental_remote_downloader_local_fallback to be set for true.

See go/omit-bazel-remote-fetch-errors for more context.