### PR TITLE
DEVPROD-31493 Add Bazel Flag to Reverse Remote Asset API Download Fallback Order

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/downloader/GrpcRemoteDownloader.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/downloader/GrpcRemoteDownloader.java
@@ -82,6 +82,12 @@ public class GrpcRemoteDownloader implements AutoCloseable, Downloader {
   private static final String QUALIFIER_CHECKSUM_SRI = "checksum.sri";
   private static final String QUALIFIER_CANONICAL_ID = "bazel.canonical_id";
 
+  // When this environment variable is set to "1" in the client environment,
+  // the download order is reversed: the local (HTTP) downloader is tried first,
+  // and the remote asset API is only used as a fallback.
+  @VisibleForTesting
+  static final String REVERSE_REMOTE_API_ATTEMPT_ORDER_ENV = "REVERSE_REMOTE_API_ATTEMPT_ORDER";
+
   // The `:` character is not permitted in an HTTP header name. So, we use it to
   // delimit the qualifier prefix which denotes an HTTP header qualifer from the
   // header name itself.
@@ -131,6 +137,32 @@ public class GrpcRemoteDownloader implements AutoCloseable, Downloader {
       Map<String, String> clientEnv,
       Optional<String> type)
       throws IOException, InterruptedException {
+    boolean localFirst =
+        fallbackDownloader != null
+            && "1".equals(clientEnv.get(REVERSE_REMOTE_API_ATTEMPT_ORDER_ENV));
+
+    if (localFirst) {
+      try {
+        fallbackDownloader.download(
+            urls,
+            headers,
+            credentials,
+            checksum,
+            canonicalId,
+            destination,
+            eventHandler,
+            clientEnv,
+            type);
+        return;
+      } catch (IOException e) {
+        eventHandler.handle(
+            Event.warn(
+                "Local download failed: "
+                    + e.getMessage()
+                    + ", trying remote downloader"));
+      }
+    }
+
     RequestMetadata metadata =
         TracingMetadataUtils.buildMetadata(buildRequestId, commandId, "remote_downloader", null);
     RemoteActionExecutionContext remoteActionExecutionContext =
@@ -159,11 +191,11 @@ public class GrpcRemoteDownloader implements AutoCloseable, Downloader {
           });
 
     } catch (StatusRuntimeException | IOException e) {
-      if (fallbackDownloader == null) {
+      if (localFirst || fallbackDownloader == null) {
         if (e instanceof StatusRuntimeException) {
           throw new IOException(e);
         }
-        throw e;
+        throw (IOException) e;
       }
 
       Optional<String> url = urls.stream()
@@ -181,7 +213,7 @@ public class GrpcRemoteDownloader implements AutoCloseable, Downloader {
         eventHandler.handle(
             Event.warn("Remote Cache: " + Utils.grpcAwareErrorMessage(e, verboseFailures)));
       }
-      
+
       fallbackDownloader.download(
           urls,
           headers,

--- a/src/test/java/com/google/devtools/build/lib/remote/downloader/GrpcRemoteDownloaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/downloader/GrpcRemoteDownloaderTest.java
@@ -79,6 +79,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import javax.annotation.Nullable;
 import org.junit.After;
 import org.junit.Before;
@@ -178,11 +179,19 @@ public class GrpcRemoteDownloaderTest {
   private static byte[] downloadBlob(
       GrpcRemoteDownloader downloader, URL url, Optional<Checksum> checksum)
       throws IOException, InterruptedException {
+    return downloadBlob(downloader, url, checksum, ImmutableMap.of());
+  }
+
+  private static byte[] downloadBlob(
+      GrpcRemoteDownloader downloader,
+      URL url,
+      Optional<Checksum> checksum,
+      Map<String, String> clientEnv)
+      throws IOException, InterruptedException {
     final List<URL> urls = ImmutableList.of(url);
 
     final String canonicalId = "";
     final ExtendedEventHandler eventHandler = mock(ExtendedEventHandler.class);
-    final Map<String, String> clientEnv = ImmutableMap.of();
 
     Scratch scratch = new Scratch();
     final Path destination = scratch.resolve("output file path");
@@ -418,5 +427,164 @@ public class GrpcRemoteDownloaderTest {
                 .addQualifiers(
                     Qualifier.newBuilder().setName("bazel.canonical_id").setValue("canonical ID"))
                 .build());
+  }
+
+  @Test
+  public void testLocalFirstEnvVar_localSucceeds_remoteNotCalled() throws Exception {
+    // Remote service that should NOT be called.
+    final AtomicBoolean remoteCalled = new AtomicBoolean(false);
+    serviceRegistry.addService(
+        new FetchImplBase() {
+          @Override
+          public void fetchBlob(
+              FetchBlobRequest request, StreamObserver<FetchBlobResponse> responseObserver) {
+            remoteCalled.set(true);
+            responseObserver.onError(new IOException("should not be called"));
+          }
+        });
+
+    final byte[] content = "local content".getBytes(UTF_8);
+    final RemoteCacheClient cacheClient = new InMemoryCacheClient();
+    Downloader fallbackDownloader = mock(Downloader.class);
+    doAnswer(
+            invocation -> {
+              Path output = invocation.getArgument(5);
+              FileSystemUtils.writeContent(output, content);
+              return null;
+            })
+        .when(fallbackDownloader)
+        .download(any(), any(), any(), any(), any(), any(), any(), any(), any());
+    final GrpcRemoteDownloader downloader = newDownloader(cacheClient, fallbackDownloader);
+
+    Map<String, String> clientEnv =
+        ImmutableMap.of(GrpcRemoteDownloader.REVERSE_REMOTE_API_ATTEMPT_ORDER_ENV, "1");
+
+    final byte[] downloaded =
+        downloadBlob(
+            downloader,
+            new URL("http://example.com/content.txt"),
+            Optional.<Checksum>empty(),
+            clientEnv);
+
+    assertThat(downloaded).isEqualTo(content);
+    assertThat(remoteCalled.get()).isFalse();
+  }
+
+  @Test
+  public void testLocalFirstEnvVar_localFails_remoteFallback() throws Exception {
+    final byte[] content = "remote content".getBytes(UTF_8);
+    final Digest contentDigest = DIGEST_UTIL.compute(content);
+
+    serviceRegistry.addService(
+        new FetchImplBase() {
+          @Override
+          public void fetchBlob(
+              FetchBlobRequest request, StreamObserver<FetchBlobResponse> responseObserver) {
+            responseObserver.onNext(
+                FetchBlobResponse.newBuilder().setBlobDigest(contentDigest).build());
+            responseObserver.onCompleted();
+          }
+        });
+
+    final RemoteCacheClient cacheClient = new InMemoryCacheClient();
+    getFromFuture(cacheClient.uploadBlob(context, contentDigest, ByteString.copyFrom(content)));
+
+    Downloader fallbackDownloader = mock(Downloader.class);
+    doAnswer(
+            invocation -> {
+              throw new IOException("local download failed");
+            })
+        .when(fallbackDownloader)
+        .download(any(), any(), any(), any(), any(), any(), any(), any(), any());
+    final GrpcRemoteDownloader downloader = newDownloader(cacheClient, fallbackDownloader);
+
+    Map<String, String> clientEnv =
+        ImmutableMap.of(GrpcRemoteDownloader.REVERSE_REMOTE_API_ATTEMPT_ORDER_ENV, "1");
+
+    final byte[] downloaded =
+        downloadBlob(
+            downloader,
+            new URL("http://example.com/content.txt"),
+            Optional.<Checksum>empty(),
+            clientEnv);
+
+    assertThat(downloaded).isEqualTo(content);
+  }
+
+  @Test
+  public void testLocalFirstEnvVar_bothFail_throwsException() throws Exception {
+    serviceRegistry.addService(
+        new FetchImplBase() {
+          @Override
+          public void fetchBlob(
+              FetchBlobRequest request, StreamObserver<FetchBlobResponse> responseObserver) {
+            responseObserver.onError(new IOException("remote failed"));
+          }
+        });
+
+    final RemoteCacheClient cacheClient = new InMemoryCacheClient();
+    Downloader fallbackDownloader = mock(Downloader.class);
+    doAnswer(
+            invocation -> {
+              throw new IOException("local download failed");
+            })
+        .when(fallbackDownloader)
+        .download(any(), any(), any(), any(), any(), any(), any(), any(), any());
+    final GrpcRemoteDownloader downloader = newDownloader(cacheClient, fallbackDownloader);
+
+    Map<String, String> clientEnv =
+        ImmutableMap.of(GrpcRemoteDownloader.REVERSE_REMOTE_API_ATTEMPT_ORDER_ENV, "1");
+
+    assertThrows(
+        IOException.class,
+        () ->
+            downloadBlob(
+                downloader,
+                new URL("http://example.com/content.txt"),
+                Optional.<Checksum>empty(),
+                clientEnv));
+  }
+
+  @Test
+  public void testLocalFirstEnvVar_notSet_remoteCalledFirst() throws Exception {
+    final byte[] content = "remote content".getBytes(UTF_8);
+    final Digest contentDigest = DIGEST_UTIL.compute(content);
+
+    serviceRegistry.addService(
+        new FetchImplBase() {
+          @Override
+          public void fetchBlob(
+              FetchBlobRequest request, StreamObserver<FetchBlobResponse> responseObserver) {
+            responseObserver.onNext(
+                FetchBlobResponse.newBuilder().setBlobDigest(contentDigest).build());
+            responseObserver.onCompleted();
+          }
+        });
+
+    final RemoteCacheClient cacheClient = new InMemoryCacheClient();
+    getFromFuture(cacheClient.uploadBlob(context, contentDigest, ByteString.copyFrom(content)));
+
+    // Fallback that should NOT be called since remote succeeds.
+    final AtomicBoolean localCalled = new AtomicBoolean(false);
+    Downloader fallbackDownloader = mock(Downloader.class);
+    doAnswer(
+            invocation -> {
+              localCalled.set(true);
+              return null;
+            })
+        .when(fallbackDownloader)
+        .download(any(), any(), any(), any(), any(), any(), any(), any(), any());
+    final GrpcRemoteDownloader downloader = newDownloader(cacheClient, fallbackDownloader);
+
+    // Empty clientEnv — env var not set.
+    final byte[] downloaded =
+        downloadBlob(
+            downloader,
+            new URL("http://example.com/content.txt"),
+            Optional.<Checksum>empty(),
+            ImmutableMap.of());
+
+    assertThat(downloaded).isEqualTo(content);
+    assertThat(localCalled.get()).isFalse();
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/remote/downloader/GrpcRemoteDownloaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/downloader/GrpcRemoteDownloaderTest.java
@@ -79,7 +79,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 import javax.annotation.Nullable;
 import org.junit.After;
 import org.junit.Before;
@@ -179,19 +178,11 @@ public class GrpcRemoteDownloaderTest {
   private static byte[] downloadBlob(
       GrpcRemoteDownloader downloader, URL url, Optional<Checksum> checksum)
       throws IOException, InterruptedException {
-    return downloadBlob(downloader, url, checksum, ImmutableMap.of());
-  }
-
-  private static byte[] downloadBlob(
-      GrpcRemoteDownloader downloader,
-      URL url,
-      Optional<Checksum> checksum,
-      Map<String, String> clientEnv)
-      throws IOException, InterruptedException {
     final List<URL> urls = ImmutableList.of(url);
 
     final String canonicalId = "";
     final ExtendedEventHandler eventHandler = mock(ExtendedEventHandler.class);
+    final Map<String, String> clientEnv = ImmutableMap.of();
 
     Scratch scratch = new Scratch();
     final Path destination = scratch.resolve("output file path");
@@ -427,164 +418,5 @@ public class GrpcRemoteDownloaderTest {
                 .addQualifiers(
                     Qualifier.newBuilder().setName("bazel.canonical_id").setValue("canonical ID"))
                 .build());
-  }
-
-  @Test
-  public void testLocalFirstEnvVar_localSucceeds_remoteNotCalled() throws Exception {
-    // Remote service that should NOT be called.
-    final AtomicBoolean remoteCalled = new AtomicBoolean(false);
-    serviceRegistry.addService(
-        new FetchImplBase() {
-          @Override
-          public void fetchBlob(
-              FetchBlobRequest request, StreamObserver<FetchBlobResponse> responseObserver) {
-            remoteCalled.set(true);
-            responseObserver.onError(new IOException("should not be called"));
-          }
-        });
-
-    final byte[] content = "local content".getBytes(UTF_8);
-    final RemoteCacheClient cacheClient = new InMemoryCacheClient();
-    Downloader fallbackDownloader = mock(Downloader.class);
-    doAnswer(
-            invocation -> {
-              Path output = invocation.getArgument(5);
-              FileSystemUtils.writeContent(output, content);
-              return null;
-            })
-        .when(fallbackDownloader)
-        .download(any(), any(), any(), any(), any(), any(), any(), any(), any());
-    final GrpcRemoteDownloader downloader = newDownloader(cacheClient, fallbackDownloader);
-
-    Map<String, String> clientEnv =
-        ImmutableMap.of(GrpcRemoteDownloader.REVERSE_REMOTE_API_ATTEMPT_ORDER_ENV, "1");
-
-    final byte[] downloaded =
-        downloadBlob(
-            downloader,
-            new URL("http://example.com/content.txt"),
-            Optional.<Checksum>empty(),
-            clientEnv);
-
-    assertThat(downloaded).isEqualTo(content);
-    assertThat(remoteCalled.get()).isFalse();
-  }
-
-  @Test
-  public void testLocalFirstEnvVar_localFails_remoteFallback() throws Exception {
-    final byte[] content = "remote content".getBytes(UTF_8);
-    final Digest contentDigest = DIGEST_UTIL.compute(content);
-
-    serviceRegistry.addService(
-        new FetchImplBase() {
-          @Override
-          public void fetchBlob(
-              FetchBlobRequest request, StreamObserver<FetchBlobResponse> responseObserver) {
-            responseObserver.onNext(
-                FetchBlobResponse.newBuilder().setBlobDigest(contentDigest).build());
-            responseObserver.onCompleted();
-          }
-        });
-
-    final RemoteCacheClient cacheClient = new InMemoryCacheClient();
-    getFromFuture(cacheClient.uploadBlob(context, contentDigest, ByteString.copyFrom(content)));
-
-    Downloader fallbackDownloader = mock(Downloader.class);
-    doAnswer(
-            invocation -> {
-              throw new IOException("local download failed");
-            })
-        .when(fallbackDownloader)
-        .download(any(), any(), any(), any(), any(), any(), any(), any(), any());
-    final GrpcRemoteDownloader downloader = newDownloader(cacheClient, fallbackDownloader);
-
-    Map<String, String> clientEnv =
-        ImmutableMap.of(GrpcRemoteDownloader.REVERSE_REMOTE_API_ATTEMPT_ORDER_ENV, "1");
-
-    final byte[] downloaded =
-        downloadBlob(
-            downloader,
-            new URL("http://example.com/content.txt"),
-            Optional.<Checksum>empty(),
-            clientEnv);
-
-    assertThat(downloaded).isEqualTo(content);
-  }
-
-  @Test
-  public void testLocalFirstEnvVar_bothFail_throwsException() throws Exception {
-    serviceRegistry.addService(
-        new FetchImplBase() {
-          @Override
-          public void fetchBlob(
-              FetchBlobRequest request, StreamObserver<FetchBlobResponse> responseObserver) {
-            responseObserver.onError(new IOException("remote failed"));
-          }
-        });
-
-    final RemoteCacheClient cacheClient = new InMemoryCacheClient();
-    Downloader fallbackDownloader = mock(Downloader.class);
-    doAnswer(
-            invocation -> {
-              throw new IOException("local download failed");
-            })
-        .when(fallbackDownloader)
-        .download(any(), any(), any(), any(), any(), any(), any(), any(), any());
-    final GrpcRemoteDownloader downloader = newDownloader(cacheClient, fallbackDownloader);
-
-    Map<String, String> clientEnv =
-        ImmutableMap.of(GrpcRemoteDownloader.REVERSE_REMOTE_API_ATTEMPT_ORDER_ENV, "1");
-
-    assertThrows(
-        IOException.class,
-        () ->
-            downloadBlob(
-                downloader,
-                new URL("http://example.com/content.txt"),
-                Optional.<Checksum>empty(),
-                clientEnv));
-  }
-
-  @Test
-  public void testLocalFirstEnvVar_notSet_remoteCalledFirst() throws Exception {
-    final byte[] content = "remote content".getBytes(UTF_8);
-    final Digest contentDigest = DIGEST_UTIL.compute(content);
-
-    serviceRegistry.addService(
-        new FetchImplBase() {
-          @Override
-          public void fetchBlob(
-              FetchBlobRequest request, StreamObserver<FetchBlobResponse> responseObserver) {
-            responseObserver.onNext(
-                FetchBlobResponse.newBuilder().setBlobDigest(contentDigest).build());
-            responseObserver.onCompleted();
-          }
-        });
-
-    final RemoteCacheClient cacheClient = new InMemoryCacheClient();
-    getFromFuture(cacheClient.uploadBlob(context, contentDigest, ByteString.copyFrom(content)));
-
-    // Fallback that should NOT be called since remote succeeds.
-    final AtomicBoolean localCalled = new AtomicBoolean(false);
-    Downloader fallbackDownloader = mock(Downloader.class);
-    doAnswer(
-            invocation -> {
-              localCalled.set(true);
-              return null;
-            })
-        .when(fallbackDownloader)
-        .download(any(), any(), any(), any(), any(), any(), any(), any(), any());
-    final GrpcRemoteDownloader downloader = newDownloader(cacheClient, fallbackDownloader);
-
-    // Empty clientEnv — env var not set.
-    final byte[] downloaded =
-        downloadBlob(
-            downloader,
-            new URL("http://example.com/content.txt"),
-            Optional.<Checksum>empty(),
-            ImmutableMap.of());
-
-    assertThat(downloaded).isEqualTo(content);
-    assertThat(localCalled.get()).isFalse();
   }
 }


### PR DESCRIPTION
Normally the remote asset API is attempted first, which goes through EngFlow's (expensive) elastic load balancer. With --experimental_remote_downloader_local_fallback (a normal bazel flag), Bazel will fallback to the normal backing HTTP url if the remote asset API call fails. However, this doesn't help with cost since the remote asset API still is hit first, contributing to ELB traffic.

This PR adds an option to reverse the order of the attempts, such that the backing URL is attempted first, and the remote asset URL is attempted second.

Originally I thought this wouldn't be possible since the remote asset API is a write-through cache, so if the remote asset API is only hit on failures, the cache won't be warmed up frequently enough to actually provide redundancy.

The hack here is that we can populate the remote asset API's cache with a fraction of the traffic we're currently hitting it with by only routing a small percentage of requests through to the remote asset API on first attempt, and sending the rest through to the backing API by default.

This will keep the cache populated while dramatically reducing traffic transmitted through the ELB.

Test with a broken http_file link:                                                                     
   

>   Default order — remote downloader first:                                                                                        
>   WARNING: Remote Cache: NOT_FOUND: Fetching URL ... with curl failed
>   WARNING: Download from https://... failed: 404 Not Found                                                                                 
>                                                             
>   Reversed order — direct URL first:
>   WARNING: Local download failed: ... trying remote downloader                                                                             
>   WARNING: Remote Cache: NOT_FOUND: ...                       
>                                                                                                                                            
> The "trying remote downloader" message only appears with REVERSE_REMOTE_API_ATTEMPT_ORDER=1, confirming Bazel's custom patch recognizes this env var and flips the attempt order.    