### PR TITLE
DEVPROD-35182: Skip remote downloader for URLs known to fail remotely

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/downloader/GrpcRemoteDownloader.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/downloader/GrpcRemoteDownloader.java
@@ -141,7 +141,16 @@ public class GrpcRemoteDownloader implements AutoCloseable, Downloader {
         fallbackDownloader != null
             && "1".equals(clientEnv.get(REVERSE_REMOTE_API_ATTEMPT_ORDER_ENV));
 
-    if (localFirst) {
+    boolean useFallbackFirst =
+        fallbackDownloader != null
+            && urls.stream()
+                .map(URL::toString)
+                .anyMatch(
+                    urlStr ->
+                        options.remoteDownloadUseLocalFallbackUrls.stream()
+                            .anyMatch(urlStr::startsWith));
+
+    if (localFirst || useFallbackFirst) {
       try {
         fallbackDownloader.download(
             urls,

--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
@@ -160,6 +160,19 @@ public final class RemoteOptions extends CommonRemoteOptions {
   public List<String> remoteDownloadOmitLocalFetchWarningUrls;
 
   @Option(
+    name = "experimental_remote_download_use_local_fallback_url",
+    defaultValue = "null",
+    documentationCategory = OptionDocumentationCategory.REMOTE,
+    effectTags = {OptionEffectTag.UNKNOWN},
+    help =
+        "Automatically fall back to the local downloader when fetching an artifact whose URL"
+           + " matches this flag's value. The value of this flag is a URL prefix matched against"
+           + " the artifact URL to be downloaded, in the format of https://example.com/one/two.",
+    allowMultiple = true
+  )
+  public List<String> remoteDownloadUseLocalFallbackUrls;
+
+  @Option(
       name = "remote_header",
       converter = Converters.AssignmentConverter.class,
       defaultValue = "null",


### PR DESCRIPTION
# Ticket

[DEVPROD-35182](https://jira.mongodb.org/browse/DEVPROD-35182): Build hangs due to unauthorized ECR downloads causing core exhaustion in Engflow

# Description

Adds a new Bazel flag,
--experimental_remote_download_use_local_fallback_url, that routes downloads through the local fallback downloader first when an artifact URL matches one of the configured prefixes, bypassing the remote downloader (and its cache) entirely on success. This is useful for URLs that require authentication credentials that EngFlow does not have, where the remote downloader is guaranteed to fail and the local downloader (which runs in the user's authenticated environment) must handle the fetch.

# Testing
- [x] Ran the evergreen COMPILE_BAZEL [task](https://spruce.corp.mongodb.com/task/mms_code_health_COMPILE_BAZEL_patch_330bf127a1ceaa0f7b47b282498834789da63385_6a32f97f5590880007c75863_26_06_17_19_46_34/logs?execution=0) with the patch bazel binary where COMPILE_BAZEL task had several 401 from 664315256653.dkr.ecr.us-east-1.amazonaws.com
- [x] Ran the evergreen COMPILE_BAZEL [task](https://spruce.corp.mongodb.com/task/mms_code_health_COMPILE_BAZEL_patch_330bf127a1ceaa0f7b47b282498834789da63385_6a32fb525e04110007b6bc2c_26_06_17_19_54_12/logs?execution=0) with the patch bazel binary and the specified flag --experimental_remote_download_use_local_fallback_url=https://664315256653.dkr.ecr.us-east-1.amazonaws.com/v2/cloud-billing/cloud-billing-python-with-git where no 401 errors of the 664315256653.dkr.ecr.us-east-1.amazonaws.com URL was shown in the logs.