### PR TITLE
DEVPROD-35182: Skip remote downloader for URLs known to fail remotely

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/downloader/GrpcRemoteDownloader.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/downloader/GrpcRemoteDownloader.java
@@ -172,7 +172,16 @@ public class GrpcRemoteDownloader implements AutoCloseable, Downloader {
         httpDownloader != null
             && "1".equals(clientEnv.get(REVERSE_REMOTE_API_ATTEMPT_ORDER_ENV));
 
-    if (localFirst) {
+    boolean useFallbackFirst =
+        httpDownloader != null
+            && urls.stream()
+                .map(URL::toString)
+                .anyMatch(
+                    urlStr ->
+                        options.remoteDownloadUseLocalFallbackUrls.stream()
+                            .anyMatch(urlStr::startsWith));
+
+    if (localFirst || useFallbackFirst) {
       try {
         httpDownloader.download(
             urls,

--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
@@ -183,6 +183,19 @@ public final class RemoteOptions extends CommonRemoteOptions {
   public List<String> remoteDownloadOmitLocalFetchWarningUrls;
 
   @Option(
+    name = "experimental_remote_download_use_local_fallback_url",
+    defaultValue = "null",
+    documentationCategory = OptionDocumentationCategory.REMOTE,
+    effectTags = {OptionEffectTag.UNKNOWN},
+    help =
+        "Automatically fall back to the local downloader when fetching an artifact whose URL"
+           + " matches this flag's value. The value of this flag is a URL prefix matched against"
+           + " the artifact URL to be downloaded, in the format of https://example.com/one/two.",
+    allowMultiple = true
+  )
+  public List<String> remoteDownloadUseLocalFallbackUrls;
+
+  @Option(
       name = "remote_header",
       converter = Converters.AssignmentConverter.class,
       defaultValue = "null",


### PR DESCRIPTION
Adds a new Bazel flag,
--experimental_remote_download_use_local_fallback_url, that routes downloads through the local fallback downloader first when an artifact URL matches one of the configured prefixes, bypassing the remote downloader (and its cache) entirely on success. This is useful for URLs that require authentication credentials that EngFlow does not have, where the remote downloader is guaranteed to fail and the local downloader (which runs in the user's authenticated environment) must handle the fetch.