### PR TITLE
DEVPROD-35410: Tolerate Bazel-7-style canonical repo names in VENDOR.bazel

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/packages/VendorFileGlobals.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/VendorFileGlobals.java
@@ -18,6 +18,7 @@ import com.google.devtools.build.docgen.annot.GlobalMethods;
 import com.google.devtools.build.docgen.annot.GlobalMethods.Environment;
 import com.google.devtools.build.lib.cmdline.LabelSyntaxException;
 import com.google.devtools.build.lib.cmdline.RepositoryName;
+import java.util.Optional;
 import net.starlark.java.annot.Param;
 import net.starlark.java.annot.StarlarkMethod;
 import net.starlark.java.eval.EvalException;
@@ -44,7 +45,7 @@ public final class VendorFileGlobals {
   public void ignore(Tuple args, StarlarkThread thread) throws EvalException {
     VendorThreadContext context = VendorThreadContext.fromOrFail(thread, "ignore()");
     for (String repoName : Sequence.cast(args, String.class, "args")) {
-      context.addIgnoredRepo(getRepositoryName(repoName));
+      getRepositoryName(repoName).ifPresent(context::addIgnoredRepo);
     }
   }
 
@@ -60,18 +61,26 @@ public final class VendorFileGlobals {
   public void pin(Tuple args, StarlarkThread thread) throws EvalException {
     VendorThreadContext context = VendorThreadContext.fromOrFail(thread, "pin()");
     for (String repoName : Sequence.cast(args, String.class, "args")) {
-      context.addPinnedRepo(getRepositoryName(repoName));
+      getRepositoryName(repoName).ifPresent(context::addPinnedRepo);
     }
   }
 
-  private RepositoryName getRepositoryName(String repoName) throws EvalException {
+  private Optional<RepositoryName> getRepositoryName(String repoName) throws EvalException {
     if (!repoName.startsWith("@@")) {
       throw Starlark.errorf("the canonical repository name must start with `@@`");
     }
     try {
       repoName = repoName.substring(2);
-      return RepositoryName.create(repoName);
+      return Optional.of(RepositoryName.create(repoName));
     } catch (LabelSyntaxException e) {
+      // Bazel 7 and Bazel 8 run side-by-side in MMS, so a single VENDOR.bazel
+      // file may contain canonical repo names written in both the Bazel-7 (`~`)
+      // and Bazel-8 (`+`) styles. The current validator only accepts the `+`
+      // form; tolerate `~`-style entries by silently dropping them so the file
+      // still parses for whichever Bazel version is running.
+      if (repoName.contains("~")) {
+        return Optional.empty();
+      }
       throw Starlark.errorf("Invalid canonical repo name: %s", e.getMessage());
     }
   }


### PR DESCRIPTION
# Ticket

[DEVPROD-35410](https://jira.mongodb.org/browse/DEVPROD-35410): MMS: Bazel 8 : Add the bzlmod 8 pin paths in .vendor/VENDOR.bazel

# Description
This change relaxes canonical-repo-name parsing in VENDOR.bazel files within VendorFileGlobals.java so that legacy Bazel-7-style names containing ~ (which the current validator rejects in favor of the Bazel-8 + separator) no longer cause a parse failure. Such entries are silently dropped instead, which is necessary because Bazel 7 and Bazel 8 may run side-by-side against the same VENDOR.bazel file in MMS, and a single file must remain loadable by either version. Genuinely invalid names that do not contain ~ continue to be rejected, so the tolerance does not mask real errors.

# Testing
- [x] Ran a [patch build](http://go/ci/6a3940ea3245ed0007ce18f8) to ensure the binaries compile.
- [x] [Ran](https://sodalite.cluster.engflow.com/invocation/860eae36-faef-483a-b176-2207b5e58cfd) bazel 8 locally on my machine with the bazel 7 and bazel 8 canonical changes.